### PR TITLE
Add Halloween themed visuals and effects to dashboard

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2085 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^19.1.0
+        version: 19.2.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.25.0
+        version: 9.37.0
+      '@types/react':
+        specifier: ^19.1.2
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.7.0(vite@6.4.0)
+      eslint:
+        specifier: ^9.25.0
+        version: 9.37.0
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.37.0)
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.19
+        version: 0.4.24(eslint@9.37.0)
+      gh-pages:
+        specifier: ^6.3.0
+        version: 6.3.0
+      globals:
+        specifier: ^16.0.0
+        version: 16.4.0
+      vite:
+        specifier: ^6.3.5
+        version: 6.4.0
+
+packages:
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.28.4':
+    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.4':
+    resolution: {integrity: sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.28.3':
+    resolution: {integrity: sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.27.1':
+    resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.3':
+    resolution: {integrity: sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.27.1':
+    resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.4':
+    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.28.4':
+    resolution: {integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.25.11':
+    resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.11':
+    resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.11':
+    resolution: {integrity: sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.11':
+    resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.11':
+    resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.11':
+    resolution: {integrity: sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.11':
+    resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.11':
+    resolution: {integrity: sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.11':
+    resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.11':
+    resolution: {integrity: sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.11':
+    resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.11':
+    resolution: {integrity: sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.11':
+    resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.11':
+    resolution: {integrity: sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.11':
+    resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.11':
+    resolution: {integrity: sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.11':
+    resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.11':
+    resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.11':
+    resolution: {integrity: sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.11':
+    resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.11':
+    resolution: {integrity: sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.11':
+    resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.11':
+    resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.11':
+    resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.11':
+    resolution: {integrity: sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.11':
+    resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.0':
+    resolution: {integrity: sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.16.0':
+    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.37.0':
+    resolution: {integrity: sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.0':
+    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.52.4':
+    resolution: {integrity: sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    resolution: {integrity: sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.52.4':
+    resolution: {integrity: sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    resolution: {integrity: sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    resolution: {integrity: sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    resolution: {integrity: sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    resolution: {integrity: sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/react-dom@19.2.2':
+    resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.2':
+    resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  baseline-browser-mapping@2.8.17:
+    resolution: {integrity: sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==}
+    hasBin: true
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.26.3:
+    resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001751:
+    resolution: {integrity: sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  electron-to-chromium@1.5.237:
+    resolution: {integrity: sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==}
+
+  email-addresses@5.0.0:
+    resolution: {integrity: sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==}
+
+  esbuild@0.25.11:
+    resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.24:
+    resolution: {integrity: sha512-nLHIW7TEq3aLrEYWpVaJ1dRgFR+wLDPN8e8FpYAql/bMV2oBEfC37K0gLEGgv9fy66juNShSMV8OkTqzltcG/w==}
+    peerDependencies:
+      eslint: '>=8.40'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.37.0:
+    resolution: {integrity: sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  filename-reserved-regex@2.0.0:
+    resolution: {integrity: sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==}
+    engines: {node: '>=4'}
+
+  filenamify@4.3.0:
+    resolution: {integrity: sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==}
+    engines: {node: '>=8'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  fs-extra@11.3.2:
+    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
+    engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  gh-pages@6.3.0:
+    resolution: {integrity: sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@16.4.0:
+    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-releases@2.0.25:
+    resolution: {integrity: sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  pkg-dir@4.2.0:
+    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
+    engines: {node: '>=8'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.0:
+    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    peerDependencies:
+      react: ^19.2.0
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.52.4:
+    resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  strip-outer@1.0.1:
+    resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
+    engines: {node: '>=0.10.0'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  trim-repeated@1.0.0:
+    resolution: {integrity: sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==}
+    engines: {node: '>=0.10.0'}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  update-browserslist-db@1.1.3:
+    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite@6.4.0:
+    resolution: {integrity: sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.28.4': {}
+
+  '@babel/core@7.28.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.4)
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.4
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.28.3':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.27.2':
+    dependencies:
+      '@babel/compat-data': 7.28.4
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.26.3
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/traverse': 7.28.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.4':
+    dependencies:
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.4
+
+  '@babel/parser@7.28.4':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.4)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/template@7.27.2':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+
+  '@babel/traverse@7.28.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.28.4
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.28.4':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@esbuild/aix-ppc64@0.25.11':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/android-arm@0.25.11':
+    optional: true
+
+  '@esbuild/android-x64@0.25.11':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.11':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.11':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.11':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.11':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.11':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.11':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.11':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.11':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.11':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.11':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.11':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.11':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.11':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.11':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.11':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.11':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0)':
+    dependencies:
+      eslint: 9.37.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
+
+  '@eslint/core@0.16.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.37.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/react-dom@19.2.2(@types/react@19.2.2)':
+    dependencies:
+      '@types/react': 19.2.2
+
+  '@types/react@19.2.2':
+    dependencies:
+      csstype: 3.1.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.0)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.4)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-union@2.1.0: {}
+
+  async@3.2.6: {}
+
+  balanced-match@1.0.2: {}
+
+  baseline-browser-mapping@2.8.17: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.26.3:
+    dependencies:
+      baseline-browser-mapping: 2.8.17
+      caniuse-lite: 1.0.30001751
+      electron-to-chromium: 1.5.237
+      node-releases: 2.0.25
+      update-browserslist-db: 1.1.3(browserslist@4.26.3)
+
+  callsites@3.1.0: {}
+
+  caniuse-lite@1.0.30001751: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@13.1.0: {}
+
+  commondir@1.0.1: {}
+
+  concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csstype@3.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  electron-to-chromium@1.5.237: {}
+
+  email-addresses@5.0.0: {}
+
+  esbuild@0.25.11:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.11
+      '@esbuild/android-arm': 0.25.11
+      '@esbuild/android-arm64': 0.25.11
+      '@esbuild/android-x64': 0.25.11
+      '@esbuild/darwin-arm64': 0.25.11
+      '@esbuild/darwin-x64': 0.25.11
+      '@esbuild/freebsd-arm64': 0.25.11
+      '@esbuild/freebsd-x64': 0.25.11
+      '@esbuild/linux-arm': 0.25.11
+      '@esbuild/linux-arm64': 0.25.11
+      '@esbuild/linux-ia32': 0.25.11
+      '@esbuild/linux-loong64': 0.25.11
+      '@esbuild/linux-mips64el': 0.25.11
+      '@esbuild/linux-ppc64': 0.25.11
+      '@esbuild/linux-riscv64': 0.25.11
+      '@esbuild/linux-s390x': 0.25.11
+      '@esbuild/linux-x64': 0.25.11
+      '@esbuild/netbsd-arm64': 0.25.11
+      '@esbuild/netbsd-x64': 0.25.11
+      '@esbuild/openbsd-arm64': 0.25.11
+      '@esbuild/openbsd-x64': 0.25.11
+      '@esbuild/openharmony-arm64': 0.25.11
+      '@esbuild/sunos-x64': 0.25.11
+      '@esbuild/win32-arm64': 0.25.11
+      '@esbuild/win32-ia32': 0.25.11
+      '@esbuild/win32-x64': 0.25.11
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@1.0.5: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.37.0):
+    dependencies:
+      eslint: 9.37.0
+
+  eslint-plugin-react-refresh@0.4.24(eslint@9.37.0):
+    dependencies:
+      eslint: 9.37.0
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.37.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.4.0
+      '@eslint/core': 0.16.0
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.37.0
+      '@eslint/plugin-kit': 0.4.0
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  filename-reserved-regex@2.0.0: {}
+
+  filenamify@4.3.0:
+    dependencies:
+      filename-reserved-regex: 2.0.0
+      strip-outer: 1.0.1
+      trim-repeated: 1.0.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  fs-extra@11.3.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  gh-pages@6.3.0:
+    dependencies:
+      async: 3.2.6
+      commander: 13.1.0
+      email-addresses: 5.0.0
+      filenamify: 4.3.0
+      find-cache-dir: 3.3.2
+      fs-extra: 11.3.2
+      globby: 11.1.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@16.4.0: {}
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
+
+  jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  natural-compare@1.4.0: {}
+
+  node-releases@2.0.25: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  p-try@2.2.0: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-type@4.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  picomatch@4.0.3: {}
+
+  pkg-dir@4.2.0:
+    dependencies:
+      find-up: 4.1.0
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.0: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  rollup@4.52.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.52.4
+      '@rollup/rollup-android-arm64': 4.52.4
+      '@rollup/rollup-darwin-arm64': 4.52.4
+      '@rollup/rollup-darwin-x64': 4.52.4
+      '@rollup/rollup-freebsd-arm64': 4.52.4
+      '@rollup/rollup-freebsd-x64': 4.52.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.4
+      '@rollup/rollup-linux-arm64-gnu': 4.52.4
+      '@rollup/rollup-linux-arm64-musl': 4.52.4
+      '@rollup/rollup-linux-loong64-gnu': 4.52.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-musl': 4.52.4
+      '@rollup/rollup-linux-s390x-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-musl': 4.52.4
+      '@rollup/rollup-openharmony-arm64': 4.52.4
+      '@rollup/rollup-win32-arm64-msvc': 4.52.4
+      '@rollup/rollup-win32-ia32-msvc': 4.52.4
+      '@rollup/rollup-win32-x64-gnu': 4.52.4
+      '@rollup/rollup-win32-x64-msvc': 4.52.4
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  strip-json-comments@3.1.1: {}
+
+  strip-outer@1.0.1:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  trim-repeated@1.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  universalify@2.0.1: {}
+
+  update-browserslist-db@1.1.3(browserslist@4.26.3):
+    dependencies:
+      browserslist: 4.26.3
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite@6.4.0:
+    dependencies:
+      esbuild: 0.25.11
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yallist@3.1.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/src/App.css
+++ b/src/App.css
@@ -123,8 +123,8 @@ body::after {
   min-width: 260px;
 }
 
-.col-25 {
-  flex: 0 0 25%;
+.col-30 {
+  flex: 0 0 32%;
 }
 
 .col-fill {
@@ -181,7 +181,7 @@ body::after {
 }
 
 .widget h2 {
-  font-size: 1.45rem;
+  font-size: 1.125rem;
 }
 
 .widget h1 {
@@ -225,7 +225,7 @@ table {
 
 th,
 td {
-  padding: 0.85rem 0.45rem;
+  padding: 0.65rem 0.45rem;
   text-align: center;
   border: 1px solid rgba(58, 20, 88, 0.55);
   transition: background 0.3s ease, color 0.3s ease;
@@ -422,11 +422,12 @@ td span {
 
 .widget-controls {
   display: flex;
-  gap: 0.6rem;
+  gap: 2rem;
   flex-wrap: wrap;
   justify-content: flex-end;
   position: relative;
   z-index: 1;
+  margin-bottom: 1rem;
 }
 
 .lock-toggle {
@@ -746,7 +747,7 @@ td span {
 }
 
 @media (max-width: 1200px) {
-  .col-25 {
+  .col-30 {
     flex: 1 1 320px;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,54 +1,119 @@
-/* @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap'); */
+:root {
+  --night-950: #030009;
+  --night-900: #0a0315;
+  --night-800: #120724;
+  --night-700: #1c1036;
+  --night-600: #241348;
+  --night-400: #3b1d6b;
+  --pumpkin-500: #f97316;
+  --pumpkin-400: #fb923c;
+  --violet-400: #a855f7;
+  --violet-300: #d8b4fe;
+  --mist: rgba(255, 255, 255, 0.08);
+  color-scheme: dark;
+}
 
 body {
   min-height: 100vh;
-  background-color: #141414;
-  color: #fff;
-  /* font-family: 'Inter', sans-serif, 'Courier New', monospace; */
   margin: 0;
   font-family: "IBM Plex Mono", monospace;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+  color: #fefaff;
   display: flex;
   justify-content: center;
-  align-items: center;
-  margin: 0;
+  align-items: stretch;
+  padding: 3vh 3vw;
+  background: radial-gradient(circle at 20% 20%, #2a0f45 0%, transparent 55%),
+    radial-gradient(circle at 80% 10%, #45135a 0%, transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(249, 115, 22, 0.18) 0%, transparent 60%),
+    linear-gradient(160deg, var(--night-950), var(--night-800));
+  overflow-x: hidden;
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: -20vh -20vw;
+  pointer-events: none;
+  z-index: -1;
+}
+
+body::before {
+  background: repeating-radial-gradient(
+      circle at 10% 10%,
+      rgba(255, 255, 255, 0.08) 0,
+      rgba(255, 255, 255, 0.08) 1px,
+      transparent 1px,
+      transparent 80px
+    ),
+    repeating-linear-gradient(
+      45deg,
+      transparent 0,
+      transparent 160px,
+      rgba(255, 255, 255, 0.05) 160px,
+      rgba(255, 255, 255, 0.05) 170px
+    );
+  opacity: 0.15;
+  transform: rotate(-2deg) scale(1.1);
+  animation: slow-pan 120s linear infinite;
+}
+
+body::after {
+  background: radial-gradient(
+    circle at 50% 110%,
+    rgba(249, 115, 22, 0.25) 0%,
+    transparent 60%
+  );
+  mix-blend-mode: screen;
+  opacity: 0.6;
+}
+
+.app-shell {
+  position: relative;
+  width: min(1620px, 100%);
+  display: flex;
+  justify-content: center;
+  backdrop-filter: blur(6px);
 }
 
 .content {
-  padding: 1em;
-  max-width: 1500px;
-  /* Limita a largura máxima da .content */
   width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 1.2em;
-  box-sizing: border-box;
-  margin-left: auto;
-  margin-right: auto;
+  gap: 1.5em;
+  padding: 1.5em;
+  border-radius: 28px;
+  background: linear-gradient(165deg, rgba(12, 5, 24, 0.92), rgba(8, 3, 18, 0.84));
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(168, 85, 247, 0.15);
+  border: 1px solid rgba(168, 85, 247, 0.2);
+  position: relative;
+  overflow: hidden;
 }
 
-.container {
-  width: 100%;
-  max-width: 2000px;
-  padding-left: 1.2rem;
-  padding-right: 1.2rem;
-  box-sizing: border-box;
+.content::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(249, 115, 22, 0.16), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.12), transparent 60%);
+  pointer-events: none;
+  opacity: 0.8;
 }
 
 .row {
   display: flex;
-  justify-content: space-between;
-  gap: 1.2rem;
+  gap: 1.5rem;
   flex-wrap: wrap;
   width: 100%;
-  box-sizing: border-box;
+  position: relative;
 }
 
 .col {
-  box-sizing: border-box;
-  flex-grow: 1;
   display: flex;
+  flex: 1;
+  min-width: 260px;
 }
 
 .col-25 {
@@ -56,228 +121,111 @@ body {
 }
 
 .col-fill {
-  flex: 1;
+  flex: 1 1 0;
 }
 
 .widget {
-  background-color: #1a1a1f;
-  border-radius: 16px;
+  background: linear-gradient(160deg, rgba(22, 12, 40, 0.88), rgba(21, 12, 36, 0.6));
+  border-radius: 22px;
   flex-grow: 1;
-  padding: 1.2rem;
-  box-shadow: 0 0 30px rgba(0, 0, 0, 0.4);
+  padding: 1.35rem;
+  border: 1px solid rgba(88, 28, 135, 0.35);
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(249, 115, 22, 0.12);
+  position: relative;
+  overflow: hidden;
 }
 
-header {
+.widget::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% -10%, rgba(248, 113, 113, 0.2), transparent 40%),
+    radial-gradient(circle at 0% 120%, rgba(168, 85, 247, 0.2), transparent 50%);
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.widget header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+  position: relative;
+  z-index: 1;
 }
 
-h1,
-h2 {
-  color: #b388ff;
-  text-shadow: 0 0 5px rgba(200, 166, 255, 0.4);
-  margin-bottom: 0.25em;
-  margin-top: 0.125em;
+.widget h1,
+.widget h2 {
+  margin: 0;
+  color: var(--pumpkin-400);
+  text-shadow: 0 0 18px rgba(249, 115, 22, 0.35), 0 0 2px rgba(0, 0, 0, 0.9);
+  letter-spacing: 0.05em;
+  text-transform: lowercase;
 }
 
-button {
-  cursor: pointer;
+.widget h2 {
+  font-size: 1.45rem;
 }
 
-button:active {
-  transform: scale(1.1);
-  transition: transform 0.2s ease;
+.widget h1 {
+  font-size: 1.8rem;
+}
+
+.widget-subtitle {
+  font-size: 0.75rem;
+  color: rgba(239, 235, 255, 0.75);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
 .tabela-wrapper {
   overflow-x: auto;
+  position: relative;
+  z-index: 1;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
-  background-color: #252529;
-  border-radius: 12px;
+  background: rgba(14, 8, 24, 0.65);
+  border-radius: 18px;
   overflow: hidden;
+  border: 1px solid rgba(168, 85, 247, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(36, 10, 64, 0.9);
+}
+
+#quadroTabela thead {
+  background: linear-gradient(90deg, rgba(88, 28, 135, 0.8), rgba(168, 85, 247, 0.55));
+  color: #fdf2ff;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.78rem;
 }
 
 th,
 td {
-  padding: 0.7rem;
+  padding: 0.85rem 0.6rem;
   text-align: center;
-  border: 1px solid rgb(51, 45, 51);
-  transition: background 0.3s;
+  border: 1px solid rgba(58, 20, 88, 0.55);
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
-thead {
-  background: linear-gradient(145deg, #5e37a5, #3d2b5f);
-  color: #e5d7ff;
-  box-shadow: 0 0 20px rgba(12, 12, 12, 0.5);
+tbody tr {
+  background: rgba(12, 6, 22, 0.72);
 }
 
 tbody tr:nth-child(even) {
-  background-color: #2a2a2e;
+  background: rgba(19, 8, 30, 0.72);
 }
 
 tbody tr:hover {
-  background-color: #393945;
+  background: rgba(45, 21, 63, 0.9);
+  color: #fff2ce;
 }
 
-td.editavel:focus,
-th.editavel:focus {
-  outline: 2px solid #b388ff;
-  background-color: #3d2b5f;
-}
-
-.lock-toggle {
-  width: 48px;
-  height: 48px;
-  border: none;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(8px);
-  color: #b388ff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background 0.3s, transform 0.2s;
-}
-
-.lock-toggle:hover {
-  background: #393941;
-  transform: scale(1.1);
-}
-
-.lock-toggle i {
-  font-size: 1.5rem;
-  transition: transform 0.2s ease;
-}
-
-.card {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.5rem;
-  width: 20rem;
-  padding: 1rem;
-  background-color: #26262a;
-  border-radius: 12px;
-  box-shadow: 0 0 20px rgba(17, 17, 17, 0.4);
-}
-
-.badge {
-  padding: 0.5rem 1rem;
-  font-size: 1em;
-  color: #f1d8ff;
-  white-space: nowrap;
-  border-radius: 7px;
-  background: linear-gradient(145deg, #502f8d, #47326e);
-  box-shadow: 0 0 10px rgba(98, 70, 142, 0.5);
-  transition: transform 0.2s ease;
-}
-
-.badge:hover {
-  transform: scale(1.05);
-}
-
-.reminders {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1em;
-}
-
-.btn {
-  padding: 0.75rem 1rem;
-  background: #ffffff0d;
-  color: #d7c1ff;
-  font-family: "IBM Plex Mono", monospace;
-  font-size: 0.8rem;
-  border: none;
-  border-radius: 10px;
-  cursor: pointer;
-}
-
-.btn:hover {
-  background: #393941;
-}
-
-@keyframes pulse {
-
-  0%,
-  20%,
-  100% {
-    transform: scale(1) rotate(0deg);
-    opacity: 1;
-    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.2);
-  }
-
-  5%,
-  15% {
-    transform: scale(1.02) rotate(2deg);
-    opacity: 0.95;
-    box-shadow: 0 0 10px 4px rgba(0, 0, 0, 0.2);
-  }
-
-  10% {
-    transform: scale(1.06) rotate(-2deg);
-    opacity: 0.9;
-    box-shadow: 0 0 20px 6px rgba(0, 0, 0, 0.25);
-  }
-}
-
-.pulse {
-  animation: pulse 4s infinite;
-}
-
-.slot-container {
-  width: 98%;
-  font-size: 1rem;
-  height: 40px;
-  overflow: hidden;
-  border: 2px solid rgba(179, 136, 255, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: #1f1f23;
-  border-radius: 12px;
-  box-shadow: 0 0 7px rgba(179, 136, 255, 0.2);
-}
-
-.slot-final {
-  color: #efe6ff;
-  font-size: 1rem;
-  /* text-shadow: 0 0 5px rgba(200, 166, 255, 0.4); */
-  animation: finalPulse 0.6s ease-in-out 7;
-}
-
-@keyframes finalPulse {
-  0% {
-    transform: scale(1);
-    opacity: 0.9;
-  }
-
-  50% {
-    transform: scale(1.05);
-    opacity: 1;
-  }
-
-  100% {
-    transform: scale(1);
-    opacity: 0.9;
-  }
-}
-
-@keyframes skeleton-loading {
-  0% {
-    background-position: 200% 0;
-  }
-
-  100% {
-    background-position: -200% 0;
-  }
+td span {
+  color: rgba(236, 226, 255, 0.6);
 }
 
 .table-cell-skeleton {
@@ -285,28 +233,478 @@ th.editavel:focus {
   min-width: 50px;
   height: 18px;
   border-radius: 4px;
-  background: linear-gradient(90deg,
-      rgba(0, 0, 0, 0.25) 25%,
-      rgba(0, 0, 0, 0.4) 50%,
-      rgba(0, 0, 0, 0.25) 75%);
+  background: linear-gradient(
+    90deg,
+    rgba(249, 115, 22, 0.05) 0%,
+    rgba(255, 255, 255, 0.15) 50%,
+    rgba(249, 115, 22, 0.05) 100%
+  );
   background-size: 200% 100%;
-  animation: skeleton-loading 1.2s infinite linear;
+  animation: skeleton-loading 1.4s infinite;
+}
+
+.badge {
+  padding: 0.65rem 1.1rem;
+  font-size: 0.85rem;
+  color: #fff7ed;
+  white-space: nowrap;
+  border-radius: 999px;
+  background: linear-gradient(130deg, rgba(249, 115, 22, 0.8), rgba(88, 28, 135, 0.9));
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.badge:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.6);
+}
+
+.reminders {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  position: relative;
+  z-index: 1;
+}
+
+.clock-face {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+  background: linear-gradient(180deg, rgba(17, 6, 30, 0.7), rgba(9, 3, 20, 0.6));
+  border-radius: 18px;
+  padding: 1.4rem 1rem;
+  border: 1px solid rgba(249, 115, 22, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.28), 0 12px 24px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.clock-face::before {
+  content: "";
+  position: absolute;
+  inset: 8%;
+  border-radius: 16px;
+  background: radial-gradient(circle, rgba(249, 115, 22, 0.16) 0%, transparent 60%);
+  opacity: 0.8;
+}
+
+.clock-date {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(244, 235, 255, 0.85);
+  position: relative;
+  z-index: 1;
+}
+
+.clock-time {
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-weight: 700;
+  color: #fff5eb;
+  letter-spacing: 0.3em;
+  text-shadow: 0 0 20px rgba(249, 115, 22, 0.35), 0 3px 12px rgba(0, 0, 0, 0.65);
+  font-family: "IBM Plex Mono", monospace;
+  position: relative;
+  z-index: 1;
+}
+
+.clock-zone {
+  font-size: 0.72rem;
+  color: rgba(239, 235, 255, 0.55);
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  position: relative;
+  z-index: 1;
+}
+
+.btn {
+  padding: 0.85rem 1.2rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #fff1e6;
+  background: linear-gradient(120deg, rgba(249, 115, 22, 0.85), rgba(88, 28, 135, 0.85));
+  border: 1px solid rgba(249, 115, 22, 0.3);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+}
+
+.btn:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow: 0 14px 28px rgba(249, 115, 22, 0.3);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-active {
+  background: linear-gradient(120deg, rgba(249, 115, 22, 0.95), rgba(249, 115, 22, 0.65));
+  color: #210524;
+  box-shadow: 0 14px 30px rgba(249, 115, 22, 0.45);
+}
+
+.btn-cta {
+  width: 100%;
+  font-size: 0.95rem;
+  letter-spacing: 0.24em;
+  padding: 1.05rem 1.2rem;
+  border-radius: 14px;
+  text-align: center;
+  background: linear-gradient(90deg, rgba(249, 115, 22, 0.95), rgba(88, 28, 135, 0.95));
+}
+
+.btn-cta:disabled {
+  filter: grayscale(0.2);
+}
+
+.spin-button.is-spinning {
+  opacity: 0.75;
+  pointer-events: none;
+}
+
+.widget-controls {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  position: relative;
+  z-index: 1;
+}
+
+.lock-toggle {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(14, 6, 28, 0.85);
+  color: var(--violet-300);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.5);
+}
+
+.lock-toggle:hover {
+  transform: scale(1.08);
+  background: rgba(168, 85, 247, 0.18);
+}
+
+.card {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.65rem;
+  width: 20rem;
+  padding: 1.1rem;
+  background: rgba(19, 7, 34, 0.85);
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.2), 0 16px 36px rgba(0, 0, 0, 0.55);
+}
+
+.pulse {
+  animation: pulse 3.6s infinite;
+}
+
+.slot-container {
+  width: 98%;
+  font-size: 1rem;
+  height: 40px;
+  overflow: hidden;
+  border: 1.5px solid rgba(249, 115, 22, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(19, 7, 30, 0.75);
+  border-radius: 14px;
+  box-shadow: 0 0 12px rgba(249, 115, 22, 0.25);
 }
 
 .slot-final {
+  color: #fff2e0;
+  font-size: 1rem;
   animation: slotPop 0.5s cubic-bezier(0.22, 1.45, 0.45, 1.08);
+}
+
+@keyframes pulse {
+  0%,
+  20%,
+  100% {
+    transform: scale(1) rotate(0deg);
+    box-shadow: 0 0 0 0 rgba(249, 115, 22, 0.35);
+  }
+
+  10% {
+    transform: scale(1.05) rotate(-2deg);
+    box-shadow: 0 0 22px rgba(249, 115, 22, 0.5);
+  }
+
+  15% {
+    transform: scale(1.02) rotate(2deg);
+  }
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 0% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
 }
 
 @keyframes slotPop {
   0% {
-    transform: scale(1) rotate(-2deg);
+    transform: scale(0.9) rotate(-3deg);
   }
 
   80% {
-    transform: scale(1.18) rotate(1.5deg);
+    transform: scale(1.18) rotate(2deg);
   }
 
   100% {
-    transform: scale(1) rotate(0);
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes slow-pan {
+  0% {
+    transform: rotate(-2deg) scale(1.1) translate(0, 0);
+  }
+
+  50% {
+    transform: rotate(-3deg) scale(1.12) translate(1%, -1%);
+  }
+
+  100% {
+    transform: rotate(-2deg) scale(1.1) translate(0, 0);
+  }
+}
+
+@keyframes fog-drift {
+  0% {
+    transform: translate3d(-8%, 0, 0) scale(1.05);
+    opacity: 0.2;
+  }
+
+  50% {
+    transform: translate3d(6%, -2%, 0) scale(1.1);
+    opacity: 0.4;
+  }
+
+  100% {
+    transform: translate3d(-8%, 0, 0) scale(1.05);
+    opacity: 0.2;
+  }
+}
+
+@keyframes float-token {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+  }
+
+  50% {
+    transform: translate3d(12px, -14px, 0) rotate(6deg) scale(1.08);
+  }
+
+  100% {
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1);
+  }
+}
+
+@keyframes jump-scare-in {
+  0% {
+    transform: translate(-50%, -50%) scale(0.2);
+    opacity: 0;
+  }
+
+  20% {
+    transform: translate(-50%, -50%) scale(1.08);
+    opacity: 1;
+  }
+
+  70% {
+    transform: translate(-50%, -50%) scale(0.96);
+    opacity: 0.9;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(0.85);
+    opacity: 0;
+  }
+}
+
+.halloween-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.halloween-fog {
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(
+      circle at 20% 50%,
+      rgba(255, 255, 255, 0.08) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 80% 50%,
+      rgba(255, 255, 255, 0.05) 0%,
+      transparent 50%
+    );
+  mix-blend-mode: screen;
+  animation: fog-drift 45s ease-in-out infinite;
+  opacity: 0.35;
+}
+
+.floating-token {
+  position: absolute;
+  font-size: clamp(1.6rem, 2.2vw, 2.6rem);
+  filter: drop-shadow(0 0 12px rgba(249, 115, 22, 0.6));
+  animation-name: float-token;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+  opacity: 0.85;
+}
+
+.floating-token.ghost {
+  filter: drop-shadow(0 0 20px rgba(255, 255, 255, 0.6));
+}
+
+.floating-token.pumpkin {
+  filter: drop-shadow(0 0 18px rgba(249, 115, 22, 0.8));
+}
+
+.candle {
+  position: absolute;
+  bottom: 8%;
+  width: 22px;
+  height: 80px;
+  background: linear-gradient(180deg, #f97316, #6b21a8 70%);
+  border-radius: 12px 12px 4px 4px;
+  opacity: 0.55;
+  animation: candle-flicker 2.8s infinite ease-in-out;
+}
+
+.candle::before {
+  content: "";
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 24px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.85) 0%, rgba(249, 115, 22, 0.6) 60%, transparent 100%);
+}
+
+.candle-left {
+  left: 3%;
+}
+
+.candle-right {
+  right: 4%;
+}
+
+@keyframes candle-flicker {
+  0%,
+  100% {
+    transform: translateY(0) scaleY(1);
+    opacity: 0.65;
+  }
+
+  50% {
+    transform: translateY(-3px) scaleY(0.95);
+    opacity: 0.9;
+  }
+}
+
+.jump-scare {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(460px, 70vw);
+  height: min(420px, 65vh);
+  background: radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.95) 0%, rgba(249, 115, 22, 0.75) 45%, rgba(24, 8, 38, 0.95) 75%);
+  border-radius: 36% 38% 40% 37% / 50% 42% 45% 38%;
+  box-shadow: 0 30px 120px rgba(249, 115, 22, 0.55), 0 0 0 12px rgba(24, 3, 43, 0.85);
+  animation: jump-scare-in 3.5s forwards;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 30;
+}
+
+.jump-scare-glow {
+  position: absolute;
+  inset: -20%;
+  background: radial-gradient(circle, rgba(249, 115, 22, 0.3) 0%, transparent 70%);
+  filter: blur(20px);
+}
+
+.jump-scare-face {
+  position: relative;
+  font-size: clamp(2.5rem, 4vw, 3.8rem);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #1f0128;
+  text-shadow: 0 0 18px rgba(255, 255, 255, 0.75), 0 8px 18px rgba(0, 0, 0, 0.6);
+}
+
+.scroll-container {
+  border-radius: 18px !important;
+  border: 1.5px solid rgba(249, 115, 22, 0.45) !important;
+  background: rgba(16, 6, 28, 0.8) !important;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(168, 85, 247, 0.2) !important;
+}
+
+.scroll-item {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+@media (max-width: 1200px) {
+  .col-25 {
+    flex: 1 1 320px;
+  }
+}
+
+@media (max-width: 900px) {
+  body {
+    padding: 1.5rem;
+  }
+
+  .content {
+    padding: 1.1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -603,6 +603,10 @@ td span {
   z-index: 5;
 }
 
+.halloween-overlay--low {
+  opacity: 0.85;
+}
+
 .halloween-fog {
   position: absolute;
   inset: -10%;
@@ -619,6 +623,7 @@ td span {
   mix-blend-mode: screen;
   animation: fog-drift 45s ease-in-out infinite;
   opacity: 0.35;
+  will-change: transform, opacity;
 }
 
 .floating-token {
@@ -629,6 +634,7 @@ td span {
   animation-timing-function: ease-in-out;
   animation-iteration-count: infinite;
   opacity: 0.85;
+  will-change: transform, opacity;
 }
 
 .floating-token.ghost {
@@ -673,6 +679,55 @@ td span {
 
 .candle-right {
   right: 4%;
+}
+
+.halloween-overlay--low .halloween-fog,
+.halloween-fog[data-animate="false"] {
+  animation: none;
+  opacity: 0.22;
+  mix-blend-mode: normal;
+  transform: translate3d(0, 0, 0) scale(1);
+}
+
+.floating-token[data-animate="false"],
+.halloween-overlay--low .floating-token {
+  animation: none;
+  transform: translate3d(0, 0, 0) scale(1);
+  opacity: 0.72;
+  filter: drop-shadow(0 0 8px rgba(249, 115, 22, 0.45));
+}
+
+.halloween-overlay--low .candle {
+  animation: none;
+  opacity: 0.4;
+}
+
+.halloween-overlay--low .candle::before {
+  opacity: 0.85;
+}
+
+:root[data-low-fx] body::before {
+  animation: none;
+  opacity: 0.08;
+  transform: rotate(-1deg) scale(1.05);
+}
+
+:root[data-low-fx] body {
+  background: radial-gradient(circle at 20% 20%, #241036 0%, transparent 55%),
+    radial-gradient(circle at 80% 10%, #3a124c 0%, transparent 45%),
+    linear-gradient(160deg, var(--night-950), var(--night-800));
+}
+
+:root[data-low-fx] .app-shell {
+  backdrop-filter: none;
+  background: rgba(10, 5, 20, 0.78);
+  border-radius: 24px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.55);
+}
+
+:root[data-low-fx] .widget {
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.55),
+    inset 0 0 0 1px rgba(249, 115, 22, 0.1);
 }
 
 @keyframes candle-flicker {

--- a/src/App.css
+++ b/src/App.css
@@ -25,7 +25,11 @@ body {
   padding: 3vh 3vw;
   background: radial-gradient(circle at 20% 20%, #2a0f45 0%, transparent 55%),
     radial-gradient(circle at 80% 10%, #45135a 0%, transparent 45%),
-    radial-gradient(circle at 50% 100%, rgba(249, 115, 22, 0.18) 0%, transparent 60%),
+    radial-gradient(
+      circle at 50% 100%,
+      rgba(249, 115, 22, 0.18) 0%,
+      transparent 60%
+    ),
     linear-gradient(160deg, var(--night-950), var(--night-800));
   overflow-x: hidden;
   position: relative;
@@ -83,24 +87,27 @@ body::after {
   display: flex;
   flex-direction: column;
   gap: 1.5em;
-  padding: 1.5em;
-  border-radius: 28px;
-  background: linear-gradient(165deg, rgba(12, 5, 24, 0.92), rgba(8, 3, 18, 0.84));
-  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(168, 85, 247, 0.15);
-  border: 1px solid rgba(168, 85, 247, 0.2);
   position: relative;
   overflow: hidden;
 }
 
-.content::before {
+/* .content::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top left, rgba(249, 115, 22, 0.16), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.12), transparent 60%);
+  background: radial-gradient(
+      circle at top left,
+      rgba(249, 115, 22, 0.16),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at bottom right,
+      rgba(168, 85, 247, 0.12),
+      transparent 60%
+    );
   pointer-events: none;
   opacity: 0.8;
-}
+} */
 
 .row {
   display: flex;
@@ -125,12 +132,17 @@ body::after {
 }
 
 .widget {
-  background: linear-gradient(160deg, rgba(22, 12, 40, 0.88), rgba(21, 12, 36, 0.6));
+  background: linear-gradient(
+    160deg,
+    rgba(22, 12, 40, 0.88),
+    rgba(21, 12, 36, 0.6)
+  );
   border-radius: 22px;
   flex-grow: 1;
   padding: 1.35rem;
   border: 1px solid rgba(88, 28, 135, 0.35);
-  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(249, 115, 22, 0.12);
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.6),
+    inset 0 0 0 1px rgba(249, 115, 22, 0.12);
   position: relative;
   overflow: hidden;
 }
@@ -139,7 +151,11 @@ body::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 80% -10%, rgba(248, 113, 113, 0.2), transparent 40%),
+  background: radial-gradient(
+      circle at 80% -10%,
+      rgba(248, 113, 113, 0.2),
+      transparent 40%
+    ),
     radial-gradient(circle at 0% 120%, rgba(168, 85, 247, 0.2), transparent 50%);
   opacity: 0.35;
   pointer-events: none;
@@ -196,7 +212,11 @@ table {
 }
 
 #quadroTabela thead {
-  background: linear-gradient(90deg, rgba(88, 28, 135, 0.8), rgba(168, 85, 247, 0.55));
+  background: linear-gradient(
+    90deg,
+    rgba(88, 28, 135, 0.8),
+    rgba(168, 85, 247, 0.55)
+  );
   color: #fdf2ff;
   text-transform: uppercase;
   letter-spacing: 0.12em;
@@ -205,7 +225,7 @@ table {
 
 th,
 td {
-  padding: 0.85rem 0.6rem;
+  padding: 0.85rem 0.45rem;
   text-align: center;
   border: 1px solid rgba(58, 20, 88, 0.55);
   transition: background 0.3s ease, color 0.3s ease;
@@ -249,8 +269,13 @@ td span {
   color: #fff7ed;
   white-space: nowrap;
   border-radius: 999px;
-  background: linear-gradient(130deg, rgba(249, 115, 22, 0.8), rgba(88, 28, 135, 0.9));
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  background: linear-gradient(
+    130deg,
+    rgba(249, 115, 22, 0.8),
+    rgba(88, 28, 135, 0.9)
+  );
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.1);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   display: inline-flex;
   gap: 0.35rem;
@@ -277,11 +302,16 @@ td span {
   align-items: center;
   gap: 1rem;
   text-align: center;
-  background: linear-gradient(180deg, rgba(17, 6, 30, 0.7), rgba(9, 3, 20, 0.6));
+  background: linear-gradient(
+    180deg,
+    rgba(17, 6, 30, 0.7),
+    rgba(9, 3, 20, 0.6)
+  );
   border-radius: 18px;
   padding: 1.4rem 1rem;
   border: 1px solid rgba(249, 115, 22, 0.28);
-  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.28), 0 12px 24px rgba(0, 0, 0, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.28),
+    0 12px 24px rgba(0, 0, 0, 0.5);
   overflow: hidden;
 }
 
@@ -290,7 +320,11 @@ td span {
   position: absolute;
   inset: 8%;
   border-radius: 16px;
-  background: radial-gradient(circle, rgba(249, 115, 22, 0.16) 0%, transparent 60%);
+  background: radial-gradient(
+    circle,
+    rgba(249, 115, 22, 0.16) 0%,
+    transparent 60%
+  );
   opacity: 0.8;
 }
 
@@ -305,7 +339,7 @@ td span {
 }
 
 .clock-time {
-  font-size: clamp(2.2rem, 4vw, 3rem);
+  font-size: clamp(2rem, 3vw, 2rem);
   font-weight: 700;
   color: #fff5eb;
   letter-spacing: 0.3em;
@@ -331,7 +365,11 @@ td span {
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: #fff1e6;
-  background: linear-gradient(120deg, rgba(249, 115, 22, 0.85), rgba(88, 28, 135, 0.85));
+  background: linear-gradient(
+    120deg,
+    rgba(249, 115, 22, 0.85),
+    rgba(88, 28, 135, 0.85)
+  );
   border: 1px solid rgba(249, 115, 22, 0.3);
   border-radius: 12px;
   cursor: pointer;
@@ -350,7 +388,11 @@ td span {
 }
 
 .btn-active {
-  background: linear-gradient(120deg, rgba(249, 115, 22, 0.95), rgba(249, 115, 22, 0.65));
+  background: linear-gradient(
+    120deg,
+    rgba(249, 115, 22, 0.95),
+    rgba(249, 115, 22, 0.65)
+  );
   color: #210524;
   box-shadow: 0 14px 30px rgba(249, 115, 22, 0.45);
 }
@@ -362,7 +404,11 @@ td span {
   padding: 1.05rem 1.2rem;
   border-radius: 14px;
   text-align: center;
-  background: linear-gradient(90deg, rgba(249, 115, 22, 0.95), rgba(88, 28, 135, 0.95));
+  background: linear-gradient(
+    90deg,
+    rgba(249, 115, 22, 0.95),
+    rgba(88, 28, 135, 0.95)
+  );
 }
 
 .btn-cta:disabled {
@@ -412,7 +458,8 @@ td span {
   padding: 1.1rem;
   background: rgba(19, 7, 34, 0.85);
   border-radius: 16px;
-  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.2), 0 16px 36px rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(168, 85, 247, 0.2),
+    0 16px 36px rgba(0, 0, 0, 0.55);
 }
 
 .pulse {
@@ -611,7 +658,12 @@ td span {
   width: 16px;
   height: 24px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.85) 0%, rgba(249, 115, 22, 0.6) 60%, transparent 100%);
+  background: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.85) 0%,
+    rgba(249, 115, 22, 0.6) 60%,
+    transparent 100%
+  );
 }
 
 .candle-left {
@@ -642,9 +694,15 @@ td span {
   transform: translate(-50%, -50%);
   width: min(460px, 70vw);
   height: min(420px, 65vh);
-  background: radial-gradient(circle at 50% 40%, rgba(255, 255, 255, 0.95) 0%, rgba(249, 115, 22, 0.75) 45%, rgba(24, 8, 38, 0.95) 75%);
+  background: radial-gradient(
+    circle at 50% 40%,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(249, 115, 22, 0.75) 45%,
+    rgba(24, 8, 38, 0.95) 75%
+  );
   border-radius: 36% 38% 40% 37% / 50% 42% 45% 38%;
-  box-shadow: 0 30px 120px rgba(249, 115, 22, 0.55), 0 0 0 12px rgba(24, 3, 43, 0.85);
+  box-shadow: 0 30px 120px rgba(249, 115, 22, 0.55),
+    0 0 0 12px rgba(24, 3, 43, 0.85);
   animation: jump-scare-in 3.5s forwards;
   display: flex;
   align-items: center;
@@ -656,7 +714,11 @@ td span {
 .jump-scare-glow {
   position: absolute;
   inset: -20%;
-  background: radial-gradient(circle, rgba(249, 115, 22, 0.3) 0%, transparent 70%);
+  background: radial-gradient(
+    circle,
+    rgba(249, 115, 22, 0.3) 0%,
+    transparent 70%
+  );
   filter: blur(20px);
 }
 
@@ -674,7 +736,8 @@ td span {
   border-radius: 18px !important;
   border: 1.5px solid rgba(249, 115, 22, 0.45) !important;
   background: rgba(16, 6, 28, 0.8) !important;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(168, 85, 247, 0.2) !important;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5),
+    inset 0 0 0 1px rgba(168, 85, 247, 0.2) !important;
 }
 
 .scroll-item {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,24 +4,28 @@ import WeeklyPlanning from "./components/WeeklyPlanning";
 import Lembrettz from "./components/Lembrettz";
 import { ClockWidget } from "./components/ClockWidget";
 import Betz from "./components/Betz";
+import HalloweenFX from "./components/HalloweenFX";
 
 function App() {
   return (
-    <div className="content">
-      <div className="row">
-        <div className="col col-fill">
-          <WeeklyPlanning />
+    <div className="app-shell">
+      <HalloweenFX />
+      <div className="content">
+        <div className="row">
+          <div className="col col-fill">
+            <WeeklyPlanning />
+          </div>
         </div>
-      </div>
-      <div className="row">
-        <div className="col col-fill">
-          <Lembrettz />
-        </div>
-        <div className="col col-25">
-          <ClockWidget />
-        </div>
-        <div className="col col-25">
-          <Betz />
+        <div className="row">
+          <div className="col col-fill">
+            <Lembrettz />
+          </div>
+          <div className="col col-25">
+            <ClockWidget />
+          </div>
+          <div className="col col-25">
+            <Betz />
+          </div>
         </div>
       </div>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,13 +17,13 @@ function App() {
           </div>
         </div>
         <div className="row">
-          <div className="col col-fill">
+          <div className="col col-30">
             <Lembrettz />
           </div>
-          <div className="col col-25">
+          <div className="col col-30">
             <ClockWidget />
           </div>
-          <div className="col col-25">
+          <div className="col col-30">
             <Betz />
           </div>
         </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import HalloweenFX from "./components/HalloweenFX";
 function App() {
   return (
     <div className="app-shell">
-      <HalloweenFX />
+      {/* <HalloweenFX /> */}
       <div className="content">
         <div className="row">
           <div className="col col-fill">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import HalloweenFX from "./components/HalloweenFX";
 function App() {
   return (
     <div className="app-shell">
-      {/* <HalloweenFX /> */}
+      <HalloweenFX />
       <div className="content">
         <div className="row">
           <div className="col col-fill">

--- a/src/components/Betz.jsx
+++ b/src/components/Betz.jsx
@@ -9,7 +9,7 @@ const BASE_NAMES = [
   "Wendell",
   "Adelino",
   "Luan",
-  "Vinícius"
+  "Vinícius",
 ];
 const GIRL_NAMES = ["Samantha", "Jéssica", "Miriã"];
 const GAMEMIND_NAMES = ["Joao", "Nathanael", "Mateus"];
@@ -96,7 +96,7 @@ export default function Betz() {
       spinSoundRef.current.loop = true;
       spinSoundRef.current.currentTime = 0;
       spinSoundRef.current.play();
-    } catch { }
+    } catch {}
 
     // Tempo aleatório entre 6 e 9 segundos
     const totalSpinTime = 6 + Math.random() * 3;
@@ -112,7 +112,7 @@ export default function Betz() {
       try {
         spinSoundRef.current.pause();
         spinSoundRef.current.currentTime = 0;
-      } catch { }
+      } catch {}
 
       const chosenWinner = newShuffle[0];
       setWinner(chosenWinner);
@@ -130,7 +130,7 @@ export default function Betz() {
       try {
         winSoundRef.current.currentTime = 0;
         winSoundRef.current.play();
-      } catch { }
+      } catch {}
 
       setSpinning(false);
     }, totalSpinTime * 1000);
@@ -145,40 +145,26 @@ export default function Betz() {
           <h2>🎰 roleta macabra</h2>
           <span className="widget-subtitle">quem encara o desafio?</span>
         </div>
-        <div className="widget-controls">
-          <button
-            onClick={toggleGirls}
-            className={`btn ${window.CAN_GIRLS ? "btn-active" : ""}`}
-          >
-            {window.CAN_GIRLS ? "Girls ON" : "Girls OFF"}
-          </button>
-          <button
-            onClick={toggleGamemind}
-            className={`btn ${window.CAN_GAMEMIND ? "btn-active" : ""}`}
-          >
-            {window.CAN_GAMEMIND ? "GameMind ON" : "GameMind OFF"}
-          </button>
-        </div>
       </header>
 
-        <div
-          className="scroll-container"
-          style={{
-            height: 42,
-            overflow: "hidden",
-            borderRadius: 14,
-            border: "1.5px solid rgba(249, 115, 22, 0.45)",
-            boxShadow:
-              "0 0 0 1.5px rgba(249, 115, 22, 0.65), 0 12px 32px rgba(8, 3, 18, 0.65)",
-            position: "relative",
-            marginBottom: 16,
-            backgroundColor: "rgba(16, 6, 28, 0.88)",
-            color: "#fff3e8",
-            fontWeight: 500,
-            fontSize: "1.2em",
-            letterSpacing: ".04em",
-            userSelect: "none",
-          }}
+      <div
+        className="scroll-container"
+        style={{
+          height: 42,
+          overflow: "hidden",
+          borderRadius: 14,
+          border: "1.5px solid rgba(249, 115, 22, 0.45)",
+          boxShadow:
+            "0 0 0 1.5px rgba(249, 115, 22, 0.65), 0 12px 32px rgba(8, 3, 18, 0.65)",
+          position: "relative",
+          marginBottom: 16,
+          backgroundColor: "rgba(16, 6, 28, 0.88)",
+          color: "#fff3e8",
+          fontWeight: 500,
+          fontSize: "1.2em",
+          letterSpacing: ".04em",
+          userSelect: "none",
+        }}
       >
         <div
           ref={scrollListRef}
@@ -221,6 +207,22 @@ export default function Betz() {
         </div>
       </div>
 
+      <div className="widget-controls">
+        <button
+          onClick={toggleGirls}
+          className={`btn ${window.CAN_GIRLS ? "btn-active" : ""}`}
+          style={{ flexGrow: 1 }}
+        >
+          {window.CAN_GIRLS ? "Girls ON" : "Girls OFF"}
+        </button>
+        <button
+          onClick={toggleGamemind}
+          className={`btn ${window.CAN_GAMEMIND ? "btn-active" : ""}`}
+          style={{ flexGrow: 1 }}
+        >
+          {window.CAN_GAMEMIND ? "GM ON" : "GM OFF"}
+        </button>
+      </div>
       <button
         id="btn-bettz"
         onClick={startSpin}

--- a/src/components/Betz.jsx
+++ b/src/components/Betz.jsx
@@ -13,7 +13,7 @@ const BASE_NAMES = [
 ];
 const GIRL_NAMES = ["Samantha", "Jéssica", "Miriã"];
 const GAMEMIND_NAMES = ["Joao", "Nathanael", "Mateus"];
-const EMOJIS = ["🍀", "🔥", "🎯", "💥", "⚡️", "🌀", "🌟"];
+const EMOJIS = ["🦇", "🕯️", "🎃", "👻", "🕷️", "☠️", "🧙"];
 const SPIN_SOUND_URL = slotSound;
 const WIN_SOUND_URL = winSound;
 
@@ -141,34 +141,44 @@ export default function Betz() {
   return (
     <div className="widget">
       <header>
-        <h2 style={{ color: "#b388ff", marginBottom: 8 }}>🎲 bettz.</h2>
-        <div style={{ display: "flex", gap: "0.5em" }}>
-          <button onClick={toggleGirls} className="btn">
+        <div>
+          <h2>🎰 roleta macabra</h2>
+          <span className="widget-subtitle">quem encara o desafio?</span>
+        </div>
+        <div className="widget-controls">
+          <button
+            onClick={toggleGirls}
+            className={`btn ${window.CAN_GIRLS ? "btn-active" : ""}`}
+          >
             {window.CAN_GIRLS ? "Girls ON" : "Girls OFF"}
           </button>
-          <button onClick={toggleGamemind} className="btn">
+          <button
+            onClick={toggleGamemind}
+            className={`btn ${window.CAN_GAMEMIND ? "btn-active" : ""}`}
+          >
             {window.CAN_GAMEMIND ? "GameMind ON" : "GameMind OFF"}
           </button>
         </div>
       </header>
 
-      <div
-        className="scroll-container"
-        style={{
-          height: 42,
-          overflow: "hidden",
-          borderRadius: 14,
-          border: "1.5px solid #b388ff44",
-          boxShadow: "0 0 0 1.5px #b388ffcc, 0 3px 18px #20185c60",
-          position: "relative",
-          marginBottom: 16,
-          backgroundColor: "#1F1F23",
-          color: "#eee",
-          fontWeight: 500,
-          fontSize: "1.2em",
-          letterSpacing: ".04em",
-          userSelect: "none",
-        }}
+        <div
+          className="scroll-container"
+          style={{
+            height: 42,
+            overflow: "hidden",
+            borderRadius: 14,
+            border: "1.5px solid rgba(249, 115, 22, 0.45)",
+            boxShadow:
+              "0 0 0 1.5px rgba(249, 115, 22, 0.65), 0 12px 32px rgba(8, 3, 18, 0.65)",
+            position: "relative",
+            marginBottom: 16,
+            backgroundColor: "rgba(16, 6, 28, 0.88)",
+            color: "#fff3e8",
+            fontWeight: 500,
+            fontSize: "1.2em",
+            letterSpacing: ".04em",
+            userSelect: "none",
+          }}
       >
         <div
           ref={scrollListRef}
@@ -193,11 +203,13 @@ export default function Betz() {
                   justifyContent: "center",
                   fontWeight: isWinner ? 800 : 500,
                   fontSize: isWinner ? "1.4em" : "1.2em",
-                  color: isWinner ? "#b388ff" : "#eee",
+                  color: isWinner ? "#f97316" : "#fff3e8",
                   textShadow: isWinner
-                    ? "0 3px 18px #b388ff44, 0 1px 1px #fff2"
-                    : "0 1px 1px #23213680",
-                  filter: isWinner ? "drop-shadow(0 0 8px #b388ff99)" : "none",
+                    ? "0 3px 18px rgba(249, 115, 22, 0.45), 0 1px 1px #fff2"
+                    : "0 1px 1px rgba(35, 21, 54, 0.5)",
+                  filter: isWinner
+                    ? "drop-shadow(0 0 12px rgba(249, 115, 22, 0.55))"
+                    : "none",
                   transition: "all 0.3s ease",
                 }}
               >
@@ -213,26 +225,9 @@ export default function Betz() {
         id="btn-bettz"
         onClick={startSpin}
         disabled={spinning}
-        style={{
-          width: "100%",
-          opacity: spinning ? 0.7 : 1,
-          pointerEvents: spinning ? "none" : "auto",
-          background: spinning
-            ? "linear-gradient(90deg, #b388ff88 0%, #b388ff44 100%)"
-            : "linear-gradient(90deg, #b388ff 0%, #5b21b6 100%)",
-          color: "#fff",
-          fontWeight: 800,
-          fontSize: "1.08rem",
-          border: "none",
-          borderRadius: 10,
-          boxShadow: "0 2px 8px #18102266",
-          padding: "12px 0",
-          letterSpacing: ".04em",
-          transition: "all .13s",
-          cursor: spinning ? "not-allowed" : "pointer",
-        }}
+        className={`btn btn-cta spin-button ${spinning ? "is-spinning" : ""}`}
       >
-        {spinning ? "Girando..." : "Girar a roleta!"}
+        {spinning ? "Conjurando..." : "Invocar destino"}
       </button>
 
       <style>{`

--- a/src/components/ClockWidget.jsx
+++ b/src/components/ClockWidget.jsx
@@ -49,54 +49,20 @@ export function ClockWidget() {
 
   const { date, time } = formatDateTime(currentDateTime);
   const weekday = formatWeekday(currentDateTime);
+  const spookyWeekday = weekday.charAt(0).toUpperCase() + weekday.slice(1);
 
   return (
     <div className="widget">
       <header>
-        <h2>🕐 {weekday}</h2>
+        <div>
+          <h2>🕒 relógio encantado</h2>
+          <span className="widget-subtitle">{spookyWeekday}</span>
+        </div>
       </header>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          gap: "1rem",
-          textAlign: "center",
-        }}
-      >
-        <div
-          style={{
-            fontSize: "1.1rem",
-            fontWeight: "600",
-            color: "#e5d7ff",
-            letterSpacing: "0.5px",
-          }}
-        >
-          {date}
-        </div>
-
-        <div
-          style={{
-            fontSize: "1.8rem",
-            fontWeight: "600",
-            color: "#fff",
-            fontFamily: "monospace",
-            letterSpacing: "2px",
-            textShadow: "0 0 10px rgba(255, 255, 255, 0.3)",
-          }}
-        >
-          {time}
-        </div>
-
-        <div
-          style={{
-            fontSize: "0.7rem",
-            color: "#888",
-            marginTop: "0.5rem",
-          }}
-        >
-          UTC-3
-        </div>
+      <div className="clock-face">
+        <div className="clock-date">{date}</div>
+        <div className="clock-time">{time}</div>
+        <div className="clock-zone">UTC-3 • Recife</div>
       </div>
     </div>
   );

--- a/src/components/HalloweenFX.jsx
+++ b/src/components/HalloweenFX.jsx
@@ -1,25 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-const SPOOKY_MESSAGES = [
-  "👻 BOO!",
-  "☠️ Peguei você!",
-  "🎃 Happy Haunting!",
-  "🩸 Traga doces... se quiser viver!",
-  "🕷️ Cuidado com as teias!",
-];
-
-function getRandomBetween(min, max) {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
 export default function HalloweenFX() {
   const [showScare, setShowScare] = useState(false);
-  const [scareMessage, setScareMessage] = useState(SPOOKY_MESSAGES[0]);
   const reduceMotionRef = useRef(false);
   const showTimeoutRef = useRef(null);
   const hideTimeoutRef = useRef(null);
   const audioContextRef = useRef(null);
-  const hasMountedRef = useRef(false);
 
   const decorations = useMemo(
     () => [
@@ -37,26 +23,26 @@ export default function HalloweenFX() {
     if (hideTimeoutRef.current) window.clearTimeout(hideTimeoutRef.current);
   }, []);
 
-  const scheduleNextScare = useCallback(
-    (customDelay) => {
-      if (typeof window === "undefined") return;
+  // const scheduleNextScare = useCallback(
+  //   (customDelay) => {
+  //     if (typeof window === "undefined") return;
 
-      clearTimers();
+  //     clearTimers();
 
-      const [min, max] = reduceMotionRef.current
-        ? [180000, 300000]
-        : [60000, 120000];
-      const delay = customDelay ?? getRandomBetween(min, max);
+  //     const [min, max] = reduceMotionRef.current
+  //       ? [180000, 300000]
+  //       : [60000, 120000];
+  //     const delay = customDelay ?? getRandomBetween(min, max);
 
-      showTimeoutRef.current = window.setTimeout(() => {
-        const message =
-          SPOOKY_MESSAGES[getRandomBetween(0, SPOOKY_MESSAGES.length - 1)];
-        setScareMessage(message);
-        setShowScare(true);
-      }, delay);
-    },
-    [clearTimers]
-  );
+  //     showTimeoutRef.current = window.setTimeout(() => {
+  //       const message =
+  //         SPOOKY_MESSAGES[getRandomBetween(0, SPOOKY_MESSAGES.length - 1)];
+  //       setScareMessage(message);
+  //       setShowScare(true);
+  //     }, delay);
+  //   },
+  //   [clearTimers]
+  // );
 
   const stopAudio = useCallback(() => {
     if (audioContextRef.current) {
@@ -112,7 +98,7 @@ export default function HalloweenFX() {
         clearTimers();
         setShowScare(false);
       } else {
-        scheduleNextScare();
+        // scheduleNextScare();
       }
     };
 
@@ -124,9 +110,9 @@ export default function HalloweenFX() {
       query.addListener(updatePreference);
     }
 
-    if (!reduceMotionRef.current) {
-      scheduleNextScare(getRandomBetween(15000, 30000));
-    }
+    // if (!reduceMotionRef.current) {
+    //   scheduleNextScare(getRandomBetween(15000, 30000));
+    // }
 
     return () => {
       if (query.removeEventListener) {
@@ -137,16 +123,16 @@ export default function HalloweenFX() {
       clearTimers();
       stopAudio();
     };
-  }, [clearTimers, scheduleNextScare, stopAudio]);
+  }, [clearTimers, stopAudio]);
 
   useEffect(() => {
-    if (!showScare) {
-      if (hasMountedRef.current && !reduceMotionRef.current) {
-        scheduleNextScare();
-      }
-      hasMountedRef.current = true;
-      return undefined;
-    }
+    // if (!showScare) {
+    //   if (hasMountedRef.current && !reduceMotionRef.current) {
+    //     scheduleNextScare();
+    //   }
+    //   hasMountedRef.current = true;
+    //   return undefined;
+    // }
 
     playScream();
 
@@ -157,7 +143,7 @@ export default function HalloweenFX() {
     return () => {
       if (hideTimeoutRef.current) window.clearTimeout(hideTimeoutRef.current);
     };
-  }, [playScream, scheduleNextScare, showScare]);
+  }, [playScream, showScare]);
 
   return (
     <div className="halloween-overlay" aria-hidden="true">
@@ -178,12 +164,6 @@ export default function HalloweenFX() {
       ))}
       <span className="candle candle-left" />
       <span className="candle candle-right" />
-      {showScare && (
-        <div className="jump-scare" role="img" aria-label="Susto de halloween">
-          <div className="jump-scare-glow" />
-          <div className="jump-scare-face">{scareMessage}</div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/components/HalloweenFX.jsx
+++ b/src/components/HalloweenFX.jsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const SPOOKY_MESSAGES = [
+  "👻 BOO!",
+  "☠️ Peguei você!",
+  "🎃 Happy Haunting!",
+  "🩸 Traga doces... se quiser viver!",
+  "🕷️ Cuidado com as teias!",
+];
+
+function getRandomBetween(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export default function HalloweenFX() {
+  const [showScare, setShowScare] = useState(false);
+  const [scareMessage, setScareMessage] = useState(SPOOKY_MESSAGES[0]);
+  const reduceMotionRef = useRef(false);
+  const showTimeoutRef = useRef(null);
+  const hideTimeoutRef = useRef(null);
+  const audioContextRef = useRef(null);
+  const hasMountedRef = useRef(false);
+
+  const decorations = useMemo(
+    () => [
+      { id: "bat-1", emoji: "🦇", top: "12%", duration: 18 },
+      { id: "bat-2", emoji: "🦇", top: "28%", duration: 24 },
+      { id: "bat-3", emoji: "🦇", top: "52%", duration: 21 },
+      { id: "pumpkin", emoji: "🎃", top: "82%", duration: 16 },
+      { id: "ghost", emoji: "👻", top: "65%", duration: 26 },
+    ],
+    []
+  );
+
+  const clearTimers = useCallback(() => {
+    if (showTimeoutRef.current) window.clearTimeout(showTimeoutRef.current);
+    if (hideTimeoutRef.current) window.clearTimeout(hideTimeoutRef.current);
+  }, []);
+
+  const scheduleNextScare = useCallback(
+    (customDelay) => {
+      if (typeof window === "undefined") return;
+
+      clearTimers();
+
+      const [min, max] = reduceMotionRef.current
+        ? [180000, 300000]
+        : [60000, 120000];
+      const delay = customDelay ?? getRandomBetween(min, max);
+
+      showTimeoutRef.current = window.setTimeout(() => {
+        const message =
+          SPOOKY_MESSAGES[getRandomBetween(0, SPOOKY_MESSAGES.length - 1)];
+        setScareMessage(message);
+        setShowScare(true);
+      }, delay);
+    },
+    [clearTimers]
+  );
+
+  const stopAudio = useCallback(() => {
+    if (audioContextRef.current) {
+      try {
+        audioContextRef.current.close();
+      } catch {
+        /* ignore */
+      }
+      audioContextRef.current = null;
+    }
+  }, []);
+
+  const playScream = useCallback(() => {
+    if (typeof window === "undefined" || reduceMotionRef.current) return;
+
+    try {
+      const AudioContext = window.AudioContext || window.webkitAudioContext;
+      const context = new AudioContext();
+      audioContextRef.current = context;
+
+      const now = context.currentTime;
+      const oscillator = context.createOscillator();
+      const gain = context.createGain();
+
+      oscillator.type = "sawtooth";
+      oscillator.frequency.setValueAtTime(200, now);
+      oscillator.frequency.exponentialRampToValueAtTime(30, now + 1.8);
+
+      gain.gain.setValueAtTime(0.0001, now);
+      gain.gain.exponentialRampToValueAtTime(0.5, now + 0.08);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + 2.2);
+
+      oscillator.connect(gain);
+      gain.connect(context.destination);
+
+      oscillator.start(now);
+      oscillator.stop(now + 2.4);
+
+      oscillator.addEventListener("ended", stopAudio, { once: true });
+    } catch {
+      /* ignore audio errors */
+    }
+  }, [stopAudio]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    const updatePreference = (event) => {
+      reduceMotionRef.current = event.matches;
+      if (event.matches) {
+        clearTimers();
+        setShowScare(false);
+      } else {
+        scheduleNextScare();
+      }
+    };
+
+    reduceMotionRef.current = query.matches;
+
+    if (query.addEventListener) {
+      query.addEventListener("change", updatePreference);
+    } else if (query.addListener) {
+      query.addListener(updatePreference);
+    }
+
+    if (!reduceMotionRef.current) {
+      scheduleNextScare(getRandomBetween(15000, 30000));
+    }
+
+    return () => {
+      if (query.removeEventListener) {
+        query.removeEventListener("change", updatePreference);
+      } else if (query.removeListener) {
+        query.removeListener(updatePreference);
+      }
+      clearTimers();
+      stopAudio();
+    };
+  }, [clearTimers, scheduleNextScare, stopAudio]);
+
+  useEffect(() => {
+    if (!showScare) {
+      if (hasMountedRef.current && !reduceMotionRef.current) {
+        scheduleNextScare();
+      }
+      hasMountedRef.current = true;
+      return undefined;
+    }
+
+    playScream();
+
+    hideTimeoutRef.current = window.setTimeout(() => {
+      setShowScare(false);
+    }, 3800);
+
+    return () => {
+      if (hideTimeoutRef.current) window.clearTimeout(hideTimeoutRef.current);
+    };
+  }, [playScream, scheduleNextScare, showScare]);
+
+  return (
+    <div className="halloween-overlay" aria-hidden="true">
+      <div className="halloween-fog" />
+      {decorations.map((item, index) => (
+        <span
+          key={item.id}
+          className={`floating-token ${item.id}`}
+          style={{
+            top: item.top,
+            animationDuration: `${item.duration}s`,
+            animationDelay: `${index * 3}s`,
+            left: `${10 + index * 18}%`,
+          }}
+        >
+          {item.emoji}
+        </span>
+      ))}
+      <span className="candle candle-left" />
+      <span className="candle candle-right" />
+      {showScare && (
+        <div className="jump-scare" role="img" aria-label="Susto de halloween">
+          <div className="jump-scare-glow" />
+          <div className="jump-scare-face">{scareMessage}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Lembrettz/index.jsx
+++ b/src/components/Lembrettz/index.jsx
@@ -107,11 +107,14 @@ export default function Lembrettz() {
   return (
     <div className="widget">
       <header>
-        <h2>⏰ lembrettz.</h2>
+        <div>
+          <h2>🕯️ lembrettz assombrados</h2>
+          <span className="widget-subtitle">recados para sobreviver à semana</span>
+        </div>
       </header>
       <div className="reminders">
         <LembrettzBadge pulse={tuesdayPulse}>
-          <b>🧁Quarta do Brigadeiro:</b>{" "}
+          <b>🧁 Quarta do Brigadeiro:</b>{" "}
           {sweetDay.error ? (
             <span style={{ color: "red" }}>{sweetDay.error}</span>
           ) : (
@@ -122,21 +125,21 @@ export default function Lembrettz() {
         {/* Só mostra nas sextas */}
         {isFriday && (
           <LembrettzBadge pulse={fridayPulse}>
-            <b>Sexta:</b> Coringagem🃏
+            <b>🃏 Sexta:</b> Coringagem Sombria
           </LembrettzBadge>
         )}
 
         {/* Só mostra na primeira semana do mês */}
         {isFirstWeek && (
           <LembrettzBadge>
-            <b>Sexta da Véia</b>👵🏻
+            <b>👵🏻 Sexta da Véia</b>
           </LembrettzBadge>
         )}
 
         {/* Só mostra na semana do último friday */}
         {isLastFridayWeek && (
           <LembrettzBadge>
-            <b>Sexta:</b> Happy Hour🎉
+            <b>🎉 Sexta:</b> Happy Hour do Além
           </LembrettzBadge>
         )}
       </div>

--- a/src/components/WeeklyPlanning/index.jsx
+++ b/src/components/WeeklyPlanning/index.jsx
@@ -42,8 +42,11 @@ export default function WeeklyPlanning() {
 
   return (
     <div className="widget">
-      <header style={{ display: "flex", alignItems: "center", gap: "0.5em" }}>
-        <h1>📋 planejamento semanal</h1>
+      <header>
+        <div>
+          <h1>🎃 planejamento sombrio</h1>
+          <span className="widget-subtitle">status direto da masmorra dev</span>
+        </div>
       </header>
       <WeeklyPlanningTable rows={rows} loading={loading} error={error} />
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,11 +2,6 @@
   font-family: "IBM Plex Mono", monospace;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,65 +10,11 @@
 
 #root {
   width: 100%;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+  height: 100%;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 2.5em;
-  line-height: 1.1;
-}
-
-h2 {
-  font-size: 1.75em;
-  line-height: 1.2;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-
-button:hover {
-  border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- restyle the dashboard layout with Halloween-inspired colors, lighting, and ambient effects
- add a reusable HalloweenFX overlay with animated fog, floating icons, and periodic jump-scare moments
- refresh widget headings, reminders, clock, and bet spinner copy to match the seasonal theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f259e1e3b8832d85554d640df4f8c9