### PR TITLE
Improve Halloween FX performance on low-power displays

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -603,6 +603,10 @@ td span {
   z-index: 5;
 }
 
+.halloween-overlay--low {
+  opacity: 0.85;
+}
+
 .halloween-fog {
   position: absolute;
   inset: -10%;
@@ -619,6 +623,7 @@ td span {
   mix-blend-mode: screen;
   animation: fog-drift 45s ease-in-out infinite;
   opacity: 0.35;
+  will-change: transform, opacity;
 }
 
 .floating-token {
@@ -629,6 +634,7 @@ td span {
   animation-timing-function: ease-in-out;
   animation-iteration-count: infinite;
   opacity: 0.85;
+  will-change: transform, opacity;
 }
 
 .floating-token.ghost {
@@ -673,6 +679,55 @@ td span {
 
 .candle-right {
   right: 4%;
+}
+
+.halloween-overlay--low .halloween-fog,
+.halloween-fog[data-animate="false"] {
+  animation: none;
+  opacity: 0.22;
+  mix-blend-mode: normal;
+  transform: translate3d(0, 0, 0) scale(1);
+}
+
+.floating-token[data-animate="false"],
+.halloween-overlay--low .floating-token {
+  animation: none;
+  transform: translate3d(0, 0, 0) scale(1);
+  opacity: 0.72;
+  filter: drop-shadow(0 0 8px rgba(249, 115, 22, 0.45));
+}
+
+.halloween-overlay--low .candle {
+  animation: none;
+  opacity: 0.4;
+}
+
+.halloween-overlay--low .candle::before {
+  opacity: 0.85;
+}
+
+:root[data-low-fx] body::before {
+  animation: none;
+  opacity: 0.08;
+  transform: rotate(-1deg) scale(1.05);
+}
+
+:root[data-low-fx] body {
+  background: radial-gradient(circle at 20% 20%, #241036 0%, transparent 55%),
+    radial-gradient(circle at 80% 10%, #3a124c 0%, transparent 45%),
+    linear-gradient(160deg, var(--night-950), var(--night-800));
+}
+
+:root[data-low-fx] .app-shell {
+  backdrop-filter: none;
+  background: rgba(10, 5, 20, 0.78);
+  border-radius: 24px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.55);
+}
+
+:root[data-low-fx] .widget {
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.55),
+    inset 0 0 0 1px rgba(249, 115, 22, 0.1);
 }
 
 @keyframes candle-flicker {


### PR DESCRIPTION
## Summary
- detect low-power or reduced-motion environments at runtime and toggle a lightweight FX mode for the Halloween overlay
- pause fog, token, and candle animations plus disable backdrop blur when the lightweight mode is active to keep visuals while reducing GPU cost
- guard the scream effect so audio only plays when the jump scare is actually shown

## Testing
- npm run lint *(fails: existing lint errors in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68f274273e74832db9cef4d8c7c772e2